### PR TITLE
Upgrade schema-utils, and handle single quotes in large JSON files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "loader-utils": "^2.0.0",
-    "schema-utils": "^2.7.1"
+    "schema-utils": "^3.0.0"
   },
   "devDependencies": {
     "codecov": "^3.7.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { getOptions } = require('loader-utils')
-const validateOptions = require('schema-utils')
+const { validate } = require('schema-utils')
 
 const schema = require('./options.json')
 
@@ -15,7 +15,7 @@ function shouldInline(limit, size) {
 module.exports = function (source) {
   const options = Object.assign({}, DEFAULT_OPTIONS, getOptions(this))
 
-  validateOptions(schema, options, 'JSON Perf Loader')
+  validate(schema, options, 'JSON Perf Loader')
 
   let value
 

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ module.exports = function (source) {
     return `module.exports = ${value}`
   }
 
-  return `module.exports = JSON.parse('${JSON.stringify(value)}')`
+  return `module.exports = JSON.parse(\`${JSON.stringify(value)}\`)`
 }
 
 exports.raw = true

--- a/test/fixtures/file-big.json
+++ b/test/fixtures/file-big.json
@@ -1327,6 +1327,9 @@
     },
     {
       "foooooooooooooooooooooooo": "barararararararararararararararararararararararararararararar"
+    },
+    {
+      "with-single-quotes": "this 'should' also work"
     }
   ]
   

--- a/test/loader-big.test.js
+++ b/test/loader-big.test.js
@@ -13,6 +13,7 @@ describe('Loader', () => {
     const stats = await webpack('fixture-big.js', config)
     const [{ source }] = stats.toJson().modules
 
-    expect(source).toMatch('JSON.parse')
+    // this will fail when there is an error e.g: `throw new Error...`
+    expect(source.startsWith('module.exports = JSON.parse')).toEqual(true)
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,7 +541,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/json-schema@^7.0.5":
+"@types/json-schema@^7.0.6":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
@@ -796,10 +796,20 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.2, ajv@^6.12.3:
   version "6.12.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
   integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.5:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -4414,13 +4424,13 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.7.1:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.7.1.tgz#1ca4f32d1b24c590c203b8e7a50bf0ea4cd394d7"
-  integrity sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
   dependencies:
-    "@types/json-schema" "^7.0.5"
-    ajv "^6.12.4"
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
 semver-compare@^1.0.0:


### PR DESCRIPTION
First off, thank you for this loader!

This PR upgrades schema-utils, and updates the breaking change. https://github.com/webpack/schema-utils/releases/tag/v3.0.0.

Additionally, updated the test to be more strict about errors. In [50f3270](https://github.com/justjavac/json-perf-loader/commit/50f3270fa75d7a8015bd44e44434aea2b0c9e329), I added a use case with single quotes in `file-big.json`, but the test still passed w/o changes.  On errors, the webpack `source` will start with `throw new Error`, so the test was updated accordingly to detect any errors.

In [8768142](https://github.com/justjavac/json-perf-loader/commit/876814218662cbec3868cc991be6f8c5f59b0b2e), the source is updated to handle this use-case. Updated test will pass.