### PR TITLE
Handle escaped double quotes in JSON

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,9 @@ module.exports = function (source) {
     return `module.exports = ${value}`
   }
 
-  return `module.exports = JSON.parse(\`${JSON.stringify(value)}\`)`
+  // the outer JSON.stringify is parsed by JavaScript
+  // the inner JSON.stringify is parsed by JSON.parse
+  return `module.exports = JSON.parse(${JSON.stringify(JSON.stringify(value))})`
 }
 
 exports.raw = true

--- a/test/fixtures/file-big.json
+++ b/test/fixtures/file-big.json
@@ -1330,6 +1330,8 @@
     },
     {
       "with-single-quotes": "this 'should' also work"
+    },
+    {
+      "with-double-\"quotes\"": "this \"should\" also work"
     }
-  ]
-  
+]

--- a/test/loader-big.test.js
+++ b/test/loader-big.test.js
@@ -15,5 +15,8 @@ describe('Loader', () => {
 
     // this will fail when there is an error e.g: `throw new Error...`
     expect(source.startsWith('module.exports = JSON.parse')).toEqual(true)
+
+    // validate syntax
+    expect(() => eval(source)).not.toThrow()
   })
 })


### PR DESCRIPTION
Extend tests to check that the produced syntax is valid (i.e. does not throw a SyntaxError when evaluated) and that escaped double quotes are supported. This test would fail on the current release.

Then I fixed the test by nesting two `JSON.stringify` calls, ensuring correctly escaped JSON.

Fixes #32 