### PR TITLE
Fix CI Node runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 20
 
       - name: install
         run: yarn --frozen-lockfile --non-interactive
@@ -18,6 +18,8 @@ jobs:
         run: yarn lint
 
       - name: test
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: yarn test:coverage
 
       - name: codecov


### PR DESCRIPTION
## Summary
- update CI from Node 12 to Node 20 so current dev dependencies can install
- set NODE_OPTIONS=--openssl-legacy-provider for the webpack 4 coverage test on OpenSSL 3 runtimes

## Verification
- yarn lint
- NODE_OPTIONS=--openssl-legacy-provider yarn test:coverage