### PR TITLE
Fix JSON loader raw handling and limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 20
 
       - name: install
         run: yarn --frozen-lockfile --non-interactive
@@ -18,6 +18,8 @@ jobs:
         run: yarn lint
 
       - name: test
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
         run: yarn test:coverage
 
       - name: codecov

--- a/src/index.js
+++ b/src/index.js
@@ -8,24 +8,28 @@ const DEFAULT_OPTIONS = {
 }
 
 function shouldInline(limit, size) {
-  return size <= parseInt(limit, 10)
+  return size < parseInt(limit, 10)
 }
 
 // https://v8.dev/blog/cost-of-javascript-2019#json
-module.exports = function (source) {
+function loader(source) {
   const options = Object.assign({}, DEFAULT_OPTIONS, getOptions(this))
 
   validate(schema, options, 'JSON Perf Loader')
 
+  const content = Buffer.isBuffer(source) ? source.toString('utf8') : source
+  const size = Buffer.isBuffer(source)
+    ? source.length
+    : Buffer.byteLength(content)
   let value
 
   try {
-    value = typeof source === 'string' ? JSON.parse(source) : source
+    value = JSON.parse(content)
   } catch (error) {
-    this.emitError(error)
+    throw error
   }
 
-  if (shouldInline(options.limit, source.length)) {
+  if (shouldInline(options.limit, size)) {
     value = JSON.stringify(value)
       .replace(/\u2028/g, '\\u2028')
       .replace(/\u2029/g, '\\u2029')
@@ -38,4 +42,6 @@ module.exports = function (source) {
   return `module.exports = JSON.parse(${JSON.stringify(JSON.stringify(value))})`
 }
 
-exports.raw = true
+loader.raw = true
+
+module.exports = loader

--- a/test/helpers/compiler.js
+++ b/test/helpers/compiler.js
@@ -1,8 +1,22 @@
 const path = require('path')
+const crypto = require('crypto')
 
 const rimraf = require('rimraf')
-const webpack = require('webpack4')
+const webpack4 = require('webpack4')
+const webpack5 = require('webpack5')
 const MemoryFS = require('memory-fs')
+
+const createHash = crypto.createHash
+
+crypto.createHash = (algorithm, options) => {
+  return createHash.call(
+    crypto,
+    algorithm === 'md4' ? 'sha256' : algorithm,
+    options,
+  )
+}
+
+const webpack = (version) => (version === 5 ? webpack5 : webpack4)
 
 const modules = (config) => {
   return {
@@ -39,13 +53,14 @@ const output = (config) => {
 module.exports = function (fixture, config, options) {
   config = {
     mode: 'development',
-    devtool: config.devtool || 'source-map',
+    devtool: config.devtool || false,
     context: path.resolve(__dirname, '..', 'fixtures'),
     entry: `./${fixture}`,
     output: output(config),
     module: modules(config),
     plugins: plugins(config),
   }
+  config.output.hashFunction = 'sha256'
 
   // eslint-disable-next-line no-param-reassign
   options = Object.assign({ output: false }, options)
@@ -54,18 +69,38 @@ module.exports = function (fixture, config, options) {
     rimraf(config.output.path)
   }
 
-  const compiler = webpack(config)
+  const compiler = webpack(options.webpack || 4)(config)
 
   if (!options.output) {
     compiler.outputFileSystem = new MemoryFS()
   }
 
+  const purgeInputFileSystem = () => {
+    if (compiler.inputFileSystem && compiler.inputFileSystem.purge) {
+      compiler.inputFileSystem.purge()
+    }
+  }
+
   return new Promise((resolve, reject) =>
     compiler.run((error, stats) => {
       if (error) {
-        reject(error)
+        purgeInputFileSystem()
+        return reject(error)
       }
 
+      if (compiler.close) {
+        return compiler.close((closeError) => {
+          purgeInputFileSystem()
+
+          if (closeError) {
+            return reject(closeError)
+          }
+
+          return resolve(stats)
+        })
+      }
+
+      purgeInputFileSystem()
       return resolve(stats)
     }),
   )

--- a/test/limit-option.test.js
+++ b/test/limit-option.test.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const path = require('path')
+
 const webpack = require('./helpers/compiler')
 
 describe('limit option', () => {
@@ -14,6 +17,26 @@ describe('limit option', () => {
     const [{ source }] = stats.toJson().modules
 
     expect(source).not.toMatch('JSON.parse')
+  })
+
+  it('uses JSON.parse when file size equals limit', async () => {
+    const limit = fs.readFileSync(
+      path.resolve(__dirname, 'fixtures/file.json'),
+    ).length
+    const config = {
+      loader: {
+        test: /\.json$/,
+        type: 'javascript/auto',
+        options: {
+          limit,
+        },
+      },
+    }
+
+    const stats = await webpack('fixture.js', config)
+    const [{ source }] = stats.toJson().modules
+
+    expect(source).toMatch('JSON.parse')
   })
 
   it('0 ({Number})', async () => {

--- a/test/loader-invalid.test.js
+++ b/test/loader-invalid.test.js
@@ -12,7 +12,10 @@ describe('Loader invaild', () => {
     const stats = await webpack('fixture-invalid.js', config)
     const { modules, errors, warnings } = stats.toJson()
 
-    expect(errors.length).toBeGreaterThan(0)
+    expect(modules[0].source).toContain('Expected property name')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message || errors[0]).toContain('Expected property name')
+    expect(errors[0].message || errors[0]).not.toContain('TypeError')
     expect(warnings).toEqual([])
   })
 })

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -6,6 +6,16 @@ describe('Loader', () => {
     expect(loader.raw).toEqual(true)
   })
 
+  it('should handle string input', () => {
+    const context = {
+      query: {},
+    }
+
+    expect(loader.call(context, '{"foo":"bar"}')).toEqual(
+      'module.exports = {"foo":"bar"}',
+    )
+  })
+
   it('should handle buffer input', () => {
     const context = {
       query: {},

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,6 +1,23 @@
 const webpack = require('./helpers/compiler')
+const loader = require('../src')
 
 describe('Loader', () => {
+  it('should export raw loader', () => {
+    expect(loader.raw).toEqual(true)
+  })
+
+  it('should handle buffer input', () => {
+    const context = {
+      query: {},
+    }
+
+    const source = Buffer.from('{"foo":"bar"}')
+
+    expect(loader.call(context, source)).toEqual(
+      'module.exports = {"foo":"bar"}',
+    )
+  })
+
   it('should works', async () => {
     const config = {
       loader: {
@@ -10,9 +27,28 @@ describe('Loader', () => {
     }
 
     const stats = await webpack('fixture.js', config)
-    const { modules, errors, warnings } = stats.toJson()
+    const { modules, errors, warnings } = stats.toJson({ source: true })
 
     expect(modules[0].source).toEqual('module.exports = {"foo":"bar"}')
+    expect(errors).toEqual([])
+    expect(warnings).toEqual([])
+  })
+
+  it('should works with webpack 5', async () => {
+    const config = {
+      loader: {
+        test: /\.json$/,
+        type: 'javascript/auto',
+      },
+    }
+
+    const stats = await webpack('fixture.js', config, { webpack: 5 })
+    const { modules, errors, warnings } = stats.toJson({ source: true })
+    const jsonModule = modules.find((module) =>
+      module.name.includes('file.json'),
+    )
+
+    expect(jsonModule.source).toEqual('module.exports = {"foo":"bar"}')
     expect(errors).toEqual([])
     expect(warnings).toEqual([])
   })


### PR DESCRIPTION
## Summary
- fix the loader export so `raw` is attached to the loader function and Buffer input is parsed as JSON text
- fail invalid JSON with the original parse error instead of emitting a secondary TypeError
- align the `limit` boundary with the README and cover webpack 5 in tests
- clean up webpack test teardown and avoid MD4-only test failures on modern Node/OpenSSL

## Tests
- yarn lint
- yarn test
- yarn test --runInBand --detectOpenHandles
- yarn test:coverage --runInBand